### PR TITLE
Add datetime deserialization test

### DIFF
--- a/pylivoltek/api_client.py
+++ b/pylivoltek/api_client.py
@@ -266,7 +266,7 @@ class ApiClient(object):
         elif klass == datetime.date:
             return self.__deserialize_date(data)
         elif klass == datetime.datetime:
-            return self.__deserialize_datatime(data)
+            return self.__deserialize_datetime(data)
         else:
             return self.__deserialize_model(data, klass)
 
@@ -572,8 +572,8 @@ class ApiClient(object):
                 reason="Failed to parse `{0}` as date object".format(string)
             )
 
-    def __deserialize_datatime(self, string):
-        """Deserializes string to datetime.
+    def __deserialize_datetime(self, string):
+        """Deserializes string to ``datetime.datetime``.
 
         The string should be in iso8601 datetime format.
 
@@ -593,6 +593,10 @@ class ApiClient(object):
                     .format(string)
                 )
             )
+
+    # Backwards compatibility: maintain old misspelled method name
+    def __deserialize_datatime(self, string):
+        return self.__deserialize_datetime(string)
 
     def __hasattr(self, object, name):
             return name in object.__class__.__dict__

--- a/test/test_api_client.py
+++ b/test/test_api_client.py
@@ -1,0 +1,23 @@
+import unittest
+import datetime
+
+from pylivoltek.api_client import ApiClient
+from pylivoltek.rest import ApiException
+
+
+class TestApiClientDatetime(unittest.TestCase):
+    def setUp(self):
+        self.client = ApiClient()
+
+    def test_deserialize_datetime_valid(self):
+        value = "2024-01-02T03:04:05Z"
+        result = self.client._ApiClient__deserialize_datetime(value)
+        self.assertIsInstance(result, datetime.datetime)
+
+    def test_deserialize_datetime_invalid(self):
+        with self.assertRaises(ApiException):
+            self.client._ApiClient__deserialize_datetime("not-a-date")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `__deserialize_datetime` to handle ISO-8601 strings
- keep backward compatibility via `__deserialize_datatime`
- test valid and invalid datetime deserialization

## Testing
- `pytest test/test_api_client.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68441a486e3c8323a44bc50975f8a069